### PR TITLE
fix(herald): resolve golangci-lint violations

### DIFF
--- a/herald/.golangci.yml
+++ b/herald/.golangci.yml
@@ -35,6 +35,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - linters:
+          - lll
+        path: utils/config\.go
     paths:
       - third_party$
       - builtin$

--- a/herald/internal/app/run.go
+++ b/herald/internal/app/run.go
@@ -5,9 +5,9 @@ import (
 	"sync"
 
 	kafkaEmit "github.com/TheAlpha16/isolet/herald/internal/emitter/kafka"
-	"github.com/TheAlpha16/isolet/herald/pkg/facts"
 	"github.com/TheAlpha16/isolet/herald/internal/pipeline"
 	"github.com/TheAlpha16/isolet/herald/internal/sources"
+	"github.com/TheAlpha16/isolet/herald/pkg/facts"
 	"github.com/TheAlpha16/isolet/herald/utils/kafka"
 	"github.com/TheAlpha16/isolet/herald/utils/logger"
 
@@ -24,13 +24,13 @@ type AppConfig struct {
 func RunPipeline(ctx context.Context, kafkaClient *kafka.Client, wg *sync.WaitGroup, config AppConfig) {
 	factChannel := make(chan facts.Fact, config.ChannelSize)
 	emitter := kafkaEmit.NewEmitter(config.KafkaTopic, kafkaClient)
-	pipeline := pipeline.New(emitter, config.Workers, wg)
+	p := pipeline.New(emitter, config.Workers, wg)
 
 	// start the pipeline
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		pipeline.Run(ctx, factChannel)
+		p.Run(ctx, factChannel)
 	}()
 
 	// start the source

--- a/herald/internal/emitter/kafka/kafka.go
+++ b/herald/internal/emitter/kafka/kafka.go
@@ -22,10 +22,10 @@ type kafkaEmitter struct {
 }
 
 func (e *kafkaEmitter) Emit(ctx context.Context, fact facts.Fact) error {
-	ctx, span, log := tracer.StartSpan(ctx, kafkaTracer, "herald.emit.kafka.Emit")
+	ctx, span, _ := tracer.StartSpan(ctx, kafkaTracer, "herald.emit.kafka.Emit")
 	defer span.End()
 
-	log = logger.GetAppLogger().With(
+	log := logger.GetAppLogger().With(
 		zap.String("emitter", "kafka"),
 		zap.ByteString("key", fact.Key()),
 		zap.String("fact_type", string(fact.FactType())),

--- a/herald/internal/pipeline/pipeline.go
+++ b/herald/internal/pipeline/pipeline.go
@@ -40,7 +40,9 @@ func (p *pipeline) Run(ctx context.Context, in <-chan facts.Fact) {
 
 	utils.InterruptHandlerChannel <- func() {
 		log.Info("pipeline shutting down")
-		p.emitter.Close()
+		if err := p.emitter.Close(); err != nil {
+			log.Error("failed to close emitter", zap.Error(err))
+		}
 	}
 
 	<-ctx.Done()
@@ -66,12 +68,12 @@ func (p *pipeline) runWorker(ctx context.Context, workerID int, in <-chan facts.
 				log.Debug("worker stopping because fact channel closed")
 				return
 			}
-			p.emitWithRetry(ctx, log, fact)
+			p.emitWithRetry(ctx, fact)
 		}
 	}
 }
 
-func (p *pipeline) emitWithRetry(ctx context.Context, log *zap.Logger, fact facts.Fact) {
+func (p *pipeline) emitWithRetry(ctx context.Context, fact facts.Fact) {
 	var err error
 	ctx, span, log := tracer.StartSpan(ctx, pipelineTracer, "herald.pipeline.emitWithRetry")
 	defer span.End()
@@ -106,14 +108,14 @@ func (p *pipeline) emitWithRetry(ctx context.Context, log *zap.Logger, fact fact
 	errors.HandleSpanError(ctx, span, log, "giving up after retries, dropping fact", err)
 }
 
-func New(emitter emitter.Emitter, workers int, wg *sync.WaitGroup) *pipeline {
+func New(e emitter.Emitter, workers int, wg *sync.WaitGroup) *pipeline {
 	if workers <= 0 {
 		logger.GetAppLogger().Warn("invalid worker count, defaulting to 1")
 		workers = 1
 	}
 
 	return &pipeline{
-		emitter: emitter,
+		emitter: e,
 		workers: workers,
 		wg:      wg,
 	}

--- a/herald/internal/sources/k8s/handlers.go
+++ b/herald/internal/sources/k8s/handlers.go
@@ -70,7 +70,7 @@ func handleInstance(obj any, out chan<- facts.Fact, eventType eventType) {
 	}
 
 	if instance.Spec.Team != nil {
-		var teamId int64 = instance.Spec.Team.ID
+		teamId := instance.Spec.Team.ID
 		fact.TeamID = &teamId
 	}
 

--- a/herald/internal/sources/k8s/helpers.go
+++ b/herald/internal/sources/k8s/helpers.go
@@ -31,7 +31,7 @@ func getK8sCache() (crcache.Cache, error) {
 		namespaceMap[ns] = crcache.Config{}
 	}
 
-	cache, err := crcache.New(config, crcache.Options{
+	k8sCache, err := crcache.New(config, crcache.Options{
 		Scheme:            sch,
 		DefaultNamespaces: namespaceMap,
 	})
@@ -39,7 +39,7 @@ func getK8sCache() (crcache.Cache, error) {
 		return nil, err
 	}
 
-	return cache, nil
+	return k8sCache, nil
 }
 
 func extractObject[T any](obj any) (T, bool) {

--- a/herald/internal/sources/k8s/k8s.go
+++ b/herald/internal/sources/k8s/k8s.go
@@ -84,7 +84,7 @@ func (s *k8sSource) startInformers(ctx context.Context, out chan<- facts.Fact) e
 			return errors.Raise(errors.ErrK8sInformerCreationFailed, "", err)
 		}
 
-		informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				handlerFunc(obj, out, eventTypeCreate)
 			},
@@ -94,7 +94,9 @@ func (s *k8sSource) startInformers(ctx context.Context, out chan<- facts.Fact) e
 			DeleteFunc: func(obj interface{}) {
 				handlerFunc(obj, out, eventTypeDelete)
 			},
-		})
+		}); err != nil {
+			return errors.Raise(errors.ErrK8sInformerCreationFailed, "failed to add event handler", err)
+		}
 	}
 	return nil
 }
@@ -105,14 +107,14 @@ func NewSource(ctx context.Context, wg *sync.WaitGroup) sources.Source {
 
 	ctrllog.SetLogger(ctrlzap.New(ctrlzap.UseDevMode(utils.GetConfig().Environment != utils.PROD)))
 
-	cache, err := getK8sCache()
+	k8sCache, err := getK8sCache()
 	if err != nil {
 		errors.HandleSpanError(ctx, span, log, "failed to create k8s event cache", err)
 		log.Fatal("failed to create k8s event cache", zap.Error(err))
 	}
 
 	return &k8sSource{
-		cache: cache,
+		cache: k8sCache,
 		wg:    wg,
 	}
 }

--- a/herald/internal/sources/postgres/helpers.go
+++ b/herald/internal/sources/postgres/helpers.go
@@ -70,7 +70,7 @@ func (s *pgSource) sendStandby(ctx context.Context, span trace.Span, log *zap.Lo
 }
 
 func (s *pgSource) getTables() string {
-	tables := []string{}
+	tables := make([]string, 0, len(tableHandlerMap))
 	for key := range tableHandlerMap {
 		tables = append(tables, fmt.Sprintf("\"%s\"", key))
 	}

--- a/herald/main.go
+++ b/herald/main.go
@@ -27,7 +27,9 @@ func main() {
 	wg := &sync.WaitGroup{}
 	config := utils.GetConfig()
 	tracer.InitSentry(config)
-	cache.GetCache(globalCtx)
+	if _, err := cache.GetCache(globalCtx); err != nil {
+		appLogger.Fatal("failed to initialize cache", zap.Error(err))
+	}
 
 	kafkaClient, err := kafka.NewClient()
 	if err != nil {

--- a/herald/utils/errors/constants.go
+++ b/herald/utils/errors/constants.go
@@ -43,7 +43,7 @@ var msgMap = map[ErrorCode]string{
 	// Fact errors
 	ErrFactInvalidKey:       "fact has invalid key",
 	ErrFactInvalidType:      "fact has invalid type",
-	ErrFactInvalidOccuredAt: "fact has invalid occured at timestamp",
+	ErrFactInvalidOccuredAt: "fact has invalid occurred at timestamp",
 
 	// Kafka errors
 	ErrKafkaProducerCreationFailed: "failed to create kafka producer",

--- a/herald/utils/errors/errors.go
+++ b/herald/utils/errors/errors.go
@@ -70,7 +70,7 @@ func RaiseToSentry(ctx context.Context, err error) {
 		hub.WithScope(func(scope *sentry.Scope) {
 			event.Message = fmt.Sprintf("%s : %s", e.GetCode(), e.GetMessage())
 			event.Exception = []sentry.Exception{{
-				Value:      fmt.Sprintf("%s", e.GetCode()),
+				Value:      e.GetCode(),
 				Type:       fmt.Sprintf("%T", e),
 				Stacktrace: sentry.ExtractStacktrace(e.Cause),
 			}}
@@ -82,7 +82,7 @@ func RaiseToSentry(ctx context.Context, err error) {
 	default:
 		stackErr := goerrors.Wrap(e, 1)
 		hub.WithScope(func(scope *sentry.Scope) {
-			event.Message = fmt.Sprintf("%s", e.Error())
+			event.Message = e.Error()
 			event.Exception = []sentry.Exception{{
 				Value:      e.Error(),
 				Type:       fmt.Sprintf("%T", e),

--- a/herald/utils/errors/helper.go
+++ b/herald/utils/errors/helper.go
@@ -22,12 +22,16 @@ func addTraceContextToSentryEvent(ctx context.Context, event *sentry.Event) {
 	}
 }
 
-func HandleSpanError(ctx context.Context, span trace.Span, log *zap.Logger, msg string, err error, extraFields ...zap.Field) {
+func HandleSpanError(
+	ctx context.Context, span trace.Span, log *zap.Logger,
+	msg string, err error, extraFields ...zap.Field,
+) {
 	span.RecordError(err)
 	span.SetStatus(codes.Error, msg)
 	RaiseToSentry(ctx, err)
 
-	zapFields := []zap.Field{zap.Error(err)}
+	zapFields := make([]zap.Field, 0, 1+len(extraFields))
+	zapFields = append(zapFields, zap.Error(err))
 	zapFields = append(zapFields, extraFields...)
 	log.Error(msg, zapFields...)
 }

--- a/herald/utils/logger/logger.go
+++ b/herald/utils/logger/logger.go
@@ -62,7 +62,7 @@ func (l *StandardLogger) WithFields(fields ...zapcore.Field) *StandardLogger {
 }
 
 func (l *StandardLogger) Sync() {
-	l.Logger.Sync()
+	_ = l.Logger.Sync()
 }
 
 func GetAppLogger() *StandardLogger {


### PR DESCRIPTION
## Summary
Fixes all `golangci-lint` violations in `herald` found by the CI lint pipeline.

| Linter | Fix |
|--------|-----|
| `errcheck` | Handle errors from `emitter.Close()`, `informer.AddEventHandler()`, `cache.GetCache()`, `logger.Sync()` |
| `gofmt` | Fix import ordering in `app/run.go` |
| `ineffassign` | Drop unused `log` from `tracer.StartSpan` in `kafka.go` |
| `lll` | Wrap `HandleSpanError` signature; exclude `utils/config.go` struct tags |
| `misspell` | `occured` → `occurred` in error message |
| `prealloc` | Preallocate slices in `postgres/helpers.go` and `errors/helper.go` |
| `revive/import-shadowing` | Rename `pipeline`, `emitter`, `cache` variables that shadow imports |
| `staticcheck` | Simplify `fmt.Sprintf("%s", ...)` → direct string; remove redundant `log` param in `emitWithRetry` |

## Test plan
- [ ] CI Go (herald) job passes on this PR