### PR TITLE
fix(oracle): resolve all golangci-lint violations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,71 @@
+name: lint
+
+on:
+  pull_request:
+    branches: [develop]
+
+jobs:
+  go-lint:
+    name: Go (${{ matrix.module }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module: [oracle, tide, herald]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: ${{ matrix.module }}/go.mod
+          cache-dependency-path: ${{ matrix.module }}/go.sum
+
+      - uses: golangci/golangci-lint-action@v8
+        with:
+          working-directory: ${{ matrix.module }}
+
+  ts-lint:
+    name: TypeScript (ui)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - run: npm ci
+      - run: npm run lint
+
+  elixir-lint:
+    name: Elixir (pulse)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: pulse
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.15"
+          otp-version: "26"
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            pulse/deps
+            pulse/_build
+          key: ${{ runner.os }}-mix-${{ hashFiles('pulse/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+
+      - run: mix deps.get
+      - run: mix format --check-formatted
+      - run: mix compile --warnings-as-errors
+        env:
+          MIX_ENV: dev

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+repos:
+  - repo: local
+    hooks:
+      - id: golangci-lint-oracle
+        name: golangci-lint (oracle)
+        language: system
+        entry: bash -c 'cd oracle && golangci-lint run'
+        pass_filenames: false
+        files: ^oracle/
+
+      - id: golangci-lint-tide
+        name: golangci-lint (tide)
+        language: system
+        entry: bash -c 'cd tide && golangci-lint run'
+        pass_filenames: false
+        files: ^tide/
+
+      - id: golangci-lint-herald
+        name: golangci-lint (herald)
+        language: system
+        entry: bash -c 'cd herald && golangci-lint run'
+        pass_filenames: false
+        files: ^herald/
+
+      - id: eslint
+        name: eslint (ui)
+        language: system
+        entry: bash -c 'cd ui && npm run lint'
+        pass_filenames: false
+        files: ^ui/.*\.(ts|tsx|js|jsx)$
+
+      - id: mix-format
+        name: mix format (pulse)
+        language: system
+        entry: bash -c 'cd pulse && mix format --check-formatted'
+        pass_filenames: false
+        files: ^pulse/.*\.(ex|exs)$

--- a/herald/.golangci.yml
+++ b/herald/.golangci.yml
@@ -1,0 +1,51 @@
+version: "2"
+run:
+  allow-parallel-runners: true
+linters:
+  default: none
+  enable:
+    - copyloopvar
+    - dupl
+    - errcheck
+    - goconst
+    - gocyclo
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - prealloc
+    - revive
+    - staticcheck
+    - unconvert
+    - unparam
+    - unused
+  settings:
+    revive:
+      rules:
+        - name: comment-spacings
+        - name: import-shadowing
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - lll
+        path: api/*
+      - linters:
+          - dupl
+          - lll
+        path: internal/*
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/herald/.golangci.yml
+++ b/herald/.golangci.yml
@@ -35,6 +35,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - linters:
+          - lll
+        path: utils/config\.go
     paths:
       - third_party$
       - builtin$

--- a/herald/internal/app/run.go
+++ b/herald/internal/app/run.go
@@ -5,9 +5,9 @@ import (
 	"sync"
 
 	kafkaEmit "github.com/TheAlpha16/isolet/herald/internal/emitter/kafka"
-	"github.com/TheAlpha16/isolet/herald/pkg/facts"
 	"github.com/TheAlpha16/isolet/herald/internal/pipeline"
 	"github.com/TheAlpha16/isolet/herald/internal/sources"
+	"github.com/TheAlpha16/isolet/herald/pkg/facts"
 	"github.com/TheAlpha16/isolet/herald/utils/kafka"
 	"github.com/TheAlpha16/isolet/herald/utils/logger"
 
@@ -24,13 +24,13 @@ type AppConfig struct {
 func RunPipeline(ctx context.Context, kafkaClient *kafka.Client, wg *sync.WaitGroup, config AppConfig) {
 	factChannel := make(chan facts.Fact, config.ChannelSize)
 	emitter := kafkaEmit.NewEmitter(config.KafkaTopic, kafkaClient)
-	pipeline := pipeline.New(emitter, config.Workers, wg)
+	p := pipeline.New(emitter, config.Workers, wg)
 
 	// start the pipeline
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		pipeline.Run(ctx, factChannel)
+		p.Run(ctx, factChannel)
 	}()
 
 	// start the source

--- a/herald/internal/emitter/kafka/kafka.go
+++ b/herald/internal/emitter/kafka/kafka.go
@@ -22,10 +22,10 @@ type kafkaEmitter struct {
 }
 
 func (e *kafkaEmitter) Emit(ctx context.Context, fact facts.Fact) error {
-	ctx, span, log := tracer.StartSpan(ctx, kafkaTracer, "herald.emit.kafka.Emit")
+	ctx, span, _ := tracer.StartSpan(ctx, kafkaTracer, "herald.emit.kafka.Emit")
 	defer span.End()
 
-	log = logger.GetAppLogger().With(
+	log := logger.GetAppLogger().With(
 		zap.String("emitter", "kafka"),
 		zap.ByteString("key", fact.Key()),
 		zap.String("fact_type", string(fact.FactType())),

--- a/herald/internal/pipeline/pipeline.go
+++ b/herald/internal/pipeline/pipeline.go
@@ -40,7 +40,9 @@ func (p *pipeline) Run(ctx context.Context, in <-chan facts.Fact) {
 
 	utils.InterruptHandlerChannel <- func() {
 		log.Info("pipeline shutting down")
-		p.emitter.Close()
+		if err := p.emitter.Close(); err != nil {
+			log.Error("failed to close emitter", zap.Error(err))
+		}
 	}
 
 	<-ctx.Done()
@@ -66,12 +68,12 @@ func (p *pipeline) runWorker(ctx context.Context, workerID int, in <-chan facts.
 				log.Debug("worker stopping because fact channel closed")
 				return
 			}
-			p.emitWithRetry(ctx, log, fact)
+			p.emitWithRetry(ctx, fact)
 		}
 	}
 }
 
-func (p *pipeline) emitWithRetry(ctx context.Context, log *zap.Logger, fact facts.Fact) {
+func (p *pipeline) emitWithRetry(ctx context.Context, fact facts.Fact) {
 	var err error
 	ctx, span, log := tracer.StartSpan(ctx, pipelineTracer, "herald.pipeline.emitWithRetry")
 	defer span.End()
@@ -106,14 +108,14 @@ func (p *pipeline) emitWithRetry(ctx context.Context, log *zap.Logger, fact fact
 	errors.HandleSpanError(ctx, span, log, "giving up after retries, dropping fact", err)
 }
 
-func New(emitter emitter.Emitter, workers int, wg *sync.WaitGroup) *pipeline {
+func New(e emitter.Emitter, workers int, wg *sync.WaitGroup) *pipeline {
 	if workers <= 0 {
 		logger.GetAppLogger().Warn("invalid worker count, defaulting to 1")
 		workers = 1
 	}
 
 	return &pipeline{
-		emitter: emitter,
+		emitter: e,
 		workers: workers,
 		wg:      wg,
 	}

--- a/herald/internal/sources/k8s/handlers.go
+++ b/herald/internal/sources/k8s/handlers.go
@@ -70,7 +70,7 @@ func handleInstance(obj any, out chan<- facts.Fact, eventType eventType) {
 	}
 
 	if instance.Spec.Team != nil {
-		var teamId int64 = instance.Spec.Team.ID
+		teamId := instance.Spec.Team.ID
 		fact.TeamID = &teamId
 	}
 

--- a/herald/internal/sources/k8s/helpers.go
+++ b/herald/internal/sources/k8s/helpers.go
@@ -31,7 +31,7 @@ func getK8sCache() (crcache.Cache, error) {
 		namespaceMap[ns] = crcache.Config{}
 	}
 
-	cache, err := crcache.New(config, crcache.Options{
+	k8sCache, err := crcache.New(config, crcache.Options{
 		Scheme:            sch,
 		DefaultNamespaces: namespaceMap,
 	})
@@ -39,7 +39,7 @@ func getK8sCache() (crcache.Cache, error) {
 		return nil, err
 	}
 
-	return cache, nil
+	return k8sCache, nil
 }
 
 func extractObject[T any](obj any) (T, bool) {

--- a/herald/internal/sources/k8s/k8s.go
+++ b/herald/internal/sources/k8s/k8s.go
@@ -84,7 +84,7 @@ func (s *k8sSource) startInformers(ctx context.Context, out chan<- facts.Fact) e
 			return errors.Raise(errors.ErrK8sInformerCreationFailed, "", err)
 		}
 
-		informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				handlerFunc(obj, out, eventTypeCreate)
 			},
@@ -94,7 +94,9 @@ func (s *k8sSource) startInformers(ctx context.Context, out chan<- facts.Fact) e
 			DeleteFunc: func(obj interface{}) {
 				handlerFunc(obj, out, eventTypeDelete)
 			},
-		})
+		}); err != nil {
+			return errors.Raise(errors.ErrK8sInformerCreationFailed, "failed to add event handler", err)
+		}
 	}
 	return nil
 }
@@ -105,14 +107,14 @@ func NewSource(ctx context.Context, wg *sync.WaitGroup) sources.Source {
 
 	ctrllog.SetLogger(ctrlzap.New(ctrlzap.UseDevMode(utils.GetConfig().Environment != utils.PROD)))
 
-	cache, err := getK8sCache()
+	k8sCache, err := getK8sCache()
 	if err != nil {
 		errors.HandleSpanError(ctx, span, log, "failed to create k8s event cache", err)
 		log.Fatal("failed to create k8s event cache", zap.Error(err))
 	}
 
 	return &k8sSource{
-		cache: cache,
+		cache: k8sCache,
 		wg:    wg,
 	}
 }

--- a/herald/internal/sources/postgres/helpers.go
+++ b/herald/internal/sources/postgres/helpers.go
@@ -70,7 +70,7 @@ func (s *pgSource) sendStandby(ctx context.Context, span trace.Span, log *zap.Lo
 }
 
 func (s *pgSource) getTables() string {
-	tables := []string{}
+	tables := make([]string, 0, len(tableHandlerMap))
 	for key := range tableHandlerMap {
 		tables = append(tables, fmt.Sprintf("\"%s\"", key))
 	}

--- a/herald/main.go
+++ b/herald/main.go
@@ -27,7 +27,9 @@ func main() {
 	wg := &sync.WaitGroup{}
 	config := utils.GetConfig()
 	tracer.InitSentry(config)
-	cache.GetCache(globalCtx)
+	if _, err := cache.GetCache(globalCtx); err != nil {
+		appLogger.Fatal("failed to initialize cache", zap.Error(err))
+	}
 
 	kafkaClient, err := kafka.NewClient()
 	if err != nil {

--- a/herald/utils/errors/constants.go
+++ b/herald/utils/errors/constants.go
@@ -43,7 +43,7 @@ var msgMap = map[ErrorCode]string{
 	// Fact errors
 	ErrFactInvalidKey:       "fact has invalid key",
 	ErrFactInvalidType:      "fact has invalid type",
-	ErrFactInvalidOccuredAt: "fact has invalid occured at timestamp",
+	ErrFactInvalidOccuredAt: "fact has invalid occurred at timestamp",
 
 	// Kafka errors
 	ErrKafkaProducerCreationFailed: "failed to create kafka producer",

--- a/herald/utils/errors/errors.go
+++ b/herald/utils/errors/errors.go
@@ -70,7 +70,7 @@ func RaiseToSentry(ctx context.Context, err error) {
 		hub.WithScope(func(scope *sentry.Scope) {
 			event.Message = fmt.Sprintf("%s : %s", e.GetCode(), e.GetMessage())
 			event.Exception = []sentry.Exception{{
-				Value:      fmt.Sprintf("%s", e.GetCode()),
+				Value:      e.GetCode(),
 				Type:       fmt.Sprintf("%T", e),
 				Stacktrace: sentry.ExtractStacktrace(e.Cause),
 			}}
@@ -82,7 +82,7 @@ func RaiseToSentry(ctx context.Context, err error) {
 	default:
 		stackErr := goerrors.Wrap(e, 1)
 		hub.WithScope(func(scope *sentry.Scope) {
-			event.Message = fmt.Sprintf("%s", e.Error())
+			event.Message = e.Error()
 			event.Exception = []sentry.Exception{{
 				Value:      e.Error(),
 				Type:       fmt.Sprintf("%T", e),

--- a/herald/utils/errors/helper.go
+++ b/herald/utils/errors/helper.go
@@ -22,12 +22,16 @@ func addTraceContextToSentryEvent(ctx context.Context, event *sentry.Event) {
 	}
 }
 
-func HandleSpanError(ctx context.Context, span trace.Span, log *zap.Logger, msg string, err error, extraFields ...zap.Field) {
+func HandleSpanError(
+	ctx context.Context, span trace.Span, log *zap.Logger,
+	msg string, err error, extraFields ...zap.Field,
+) {
 	span.RecordError(err)
 	span.SetStatus(codes.Error, msg)
 	RaiseToSentry(ctx, err)
 
-	zapFields := []zap.Field{zap.Error(err)}
+	zapFields := make([]zap.Field, 0, 1+len(extraFields))
+	zapFields = append(zapFields, zap.Error(err))
 	zapFields = append(zapFields, extraFields...)
 	log.Error(msg, zapFields...)
 }

--- a/herald/utils/errors/stack.go
+++ b/herald/utils/errors/stack.go
@@ -18,11 +18,11 @@ func GetStackTrace() string {
 
 	for {
 		frame, more := frames.Next()
-		sb.WriteString(fmt.Sprintf(
+		fmt.Fprintf(&sb,
 			"\t-> %s:%d (%s)\n",
 			frame.File, frame.Line,
 			path.Base(frame.Function),
-		))
+		)
 		if !more {
 			break
 		}

--- a/herald/utils/logger/logger.go
+++ b/herald/utils/logger/logger.go
@@ -62,7 +62,7 @@ func (l *StandardLogger) WithFields(fields ...zapcore.Field) *StandardLogger {
 }
 
 func (l *StandardLogger) Sync() {
-	l.Logger.Sync()
+	_ = l.Logger.Sync()
 }
 
 func GetAppLogger() *StandardLogger {

--- a/oracle/.golangci.yml
+++ b/oracle/.golangci.yml
@@ -1,0 +1,51 @@
+version: "2"
+run:
+  allow-parallel-runners: true
+linters:
+  default: none
+  enable:
+    - copyloopvar
+    - dupl
+    - errcheck
+    - goconst
+    - gocyclo
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - prealloc
+    - revive
+    - staticcheck
+    - unconvert
+    - unparam
+    - unused
+  settings:
+    revive:
+      rules:
+        - name: comment-spacings
+        - name: import-shadowing
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - lll
+        path: api/*
+      - linters:
+          - dupl
+          - lll
+        path: internal/*
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/oracle/cmd/migrate/main.go
+++ b/oracle/cmd/migrate/main.go
@@ -46,6 +46,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "failed to load gorm schema: %v\n", err)
 		os.Exit(1)
 	}
-	io.WriteString(os.Stdout, enumTypes)
-	io.WriteString(os.Stdout, stmts)
+	_, _ = io.WriteString(os.Stdout, enumTypes)
+	_, _ = io.WriteString(os.Stdout, stmts)
 }

--- a/oracle/delivery/consumer/consumer.go
+++ b/oracle/delivery/consumer/consumer.go
@@ -26,7 +26,7 @@ type Consumer struct {
 
 func (c *Consumer) Start(ctx context.Context) error {
 	ctx = errorDom.SetSrcInCtx(ctx, "oracle.consumer")
-	var topics []string
+	topics := make([]string, 0, len(c.deserializers))
 	for topic := range c.deserializers {
 		topics = append(topics, topic)
 	}

--- a/oracle/delivery/rest/rest.go
+++ b/oracle/delivery/rest/rest.go
@@ -24,7 +24,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func New(usecases *usecase.Usecases, infra *infra.Infra) *fiber.App {
+func New(usecases *usecase.Usecases, svc *infra.Infra) *fiber.App {
 	config := utils.GetConfig()
 	app := fiber.New(
 		fiber.Config{
@@ -63,13 +63,13 @@ func New(usecases *usecase.Usecases, infra *infra.Infra) *fiber.App {
 	// Setup routes
 	apiRouter := app.Group(config.Rest.APIVersionPrefix)
 	routes.RegisterHealth(apiRouter, healthHandler)
-	routes.RegisterAuth(apiRouter, authHandler, usecases.Token, infra.JWT)
-	routes.RegisterTeam(apiRouter, teamHandler, usecases.Token, infra.JWT)
+	routes.RegisterAuth(apiRouter, authHandler, usecases.Token, svc.JWT)
+	routes.RegisterTeam(apiRouter, teamHandler, usecases.Token, svc.JWT)
 	routes.RegisterEvent(apiRouter, eventHandler)
-	routes.RegisterProfile(apiRouter, profileHandler, usecases.Token, infra.JWT)
-	routes.RegisterChallenge(apiRouter, challengeHandler, usecases.Token, infra.JWT, usecases.ConfigVars)
-	routes.RegisterScore(apiRouter, scoreHandler, usecases.Token, infra.JWT, usecases.ConfigVars)
-	routes.RegisterInstance(apiRouter, instanceHandler, usecases.Token, infra.JWT, usecases.ConfigVars)
+	routes.RegisterProfile(apiRouter, profileHandler, usecases.Token, svc.JWT)
+	routes.RegisterChallenge(apiRouter, challengeHandler, usecases.Token, svc.JWT, usecases.ConfigVars)
+	routes.RegisterScore(apiRouter, scoreHandler, usecases.Token, svc.JWT, usecases.ConfigVars)
+	routes.RegisterInstance(apiRouter, instanceHandler, usecases.Token, svc.JWT, usecases.ConfigVars)
 
 	return app
 }

--- a/oracle/delivery/rest/routes/challenge.go
+++ b/oracle/delivery/rest/routes/challenge.go
@@ -11,7 +11,13 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-func RegisterChallenge(router fiber.Router, challengeHandler challengeHan.ChallengeHandler, tokenUc tokenDom.Usecase, jwtSvc jwt.JWT, cvUc cvDom.Usecase) {
+func RegisterChallenge(
+	router fiber.Router,
+	challengeHandler challengeHan.ChallengeHandler,
+	tokenUc tokenDom.Usecase,
+	jwtSvc jwt.JWT,
+	cvUc cvDom.Usecase,
+) {
 	challengeRouter := router.Group(
 		utils.RouteChallenge,
 		middleware.AuthMiddleware(tokenUc, jwtSvc),

--- a/oracle/delivery/rest/routes/instance.go
+++ b/oracle/delivery/rest/routes/instance.go
@@ -11,7 +11,13 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-func RegisterInstance(router fiber.Router, instanceHandler instanceHan.InstanceHandler, tokenUc tokenDom.Usecase, jwtSvc jwt.JWT, cvUc cvDom.Usecase) {
+func RegisterInstance(
+	router fiber.Router,
+	instanceHandler instanceHan.InstanceHandler,
+	tokenUc tokenDom.Usecase,
+	jwtSvc jwt.JWT,
+	cvUc cvDom.Usecase,
+) {
 	config := utils.GetConfig()
 
 	instanceRouter := router.Group(

--- a/oracle/delivery/rest/routes/profile.go
+++ b/oracle/delivery/rest/routes/profile.go
@@ -9,7 +9,12 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-func RegisterProfile(router fiber.Router, profileHandler profileHan.ProfileHandler, tokenUc tokenDom.Usecase, jwtSvc jwt.JWT) {
+func RegisterProfile(
+	router fiber.Router,
+	profileHandler profileHan.ProfileHandler,
+	tokenUc tokenDom.Usecase,
+	jwtSvc jwt.JWT,
+) {
 	profileRouter := router.Group(utils.RouteProfile, middleware.AuthMiddleware(tokenUc, jwtSvc))
 	profileRouter.Get(utils.RouteProfileMe, profileHandler.Me)
 	profileRouter.Get(utils.RouteProfileTeam, middleware.RequireTeamMiddleware(), profileHandler.Team)

--- a/oracle/delivery/rest/routes/score.go
+++ b/oracle/delivery/rest/routes/score.go
@@ -11,7 +11,13 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-func RegisterScore(router fiber.Router, scoreHandler scoreHan.ScoreHandler, tokenUc tokenDom.Usecase, jwtSvc jwt.JWT, cvUc cvDom.Usecase) {
+func RegisterScore(
+	router fiber.Router,
+	scoreHandler scoreHan.ScoreHandler,
+	tokenUc tokenDom.Usecase,
+	jwtSvc jwt.JWT,
+	cvUc cvDom.Usecase,
+) {
 	scoreRouter := router.Group(
 		utils.RouteScore,
 		middleware.AuthMiddleware(tokenUc, jwtSvc),

--- a/oracle/external/instance/codec.go
+++ b/oracle/external/instance/codec.go
@@ -53,7 +53,7 @@ func toTideInstance(ctx context.Context, inst *instanceDom.Instance, manifest *m
 		instance.Spec.Limits = *toCoreResource(ctx, manifest.Limits)
 	}
 
-	var endpoints []tidev1.EndpointSpec
+	endpoints := make([]tidev1.EndpointSpec, 0, len(manifest.EndpointSpecs))
 	for _, ep := range manifest.EndpointSpecs {
 		endpoints = append(endpoints, *toTideEndpointSpec(ep))
 	}
@@ -98,7 +98,9 @@ func toCoreResource(ctx context.Context, resources []*manifestDom.Resource) *cor
 	for _, res := range resources {
 		quantity, err := resource.ParseQuantity(res.Value)
 		if err != nil {
-			parseErr := errorDom.Raise(ctx, errorDom.ErrInstanceInvalidResourceQuantity, "", err, common.ExtraData{"resource_id": res.ID, "value": res.Value})
+			parseErr := errorDom.Raise(ctx, errorDom.ErrInstanceInvalidResourceQuantity, "", err, common.ExtraData{
+				"resource_id": res.ID, "value": res.Value,
+			})
 			logger.GetAppLogger().Error(
 				"invalid value for resource quantity",
 				zap.Int64("resource_id", res.ID),

--- a/oracle/external/instance/helpers.go
+++ b/oracle/external/instance/helpers.go
@@ -14,18 +14,15 @@ import (
 )
 
 // ensureInstanceReady waits until the instance is in a terminal state (Running, Failed, etc.)
-func (is *instanceSvc) ensureInstanceReady(ctx context.Context, old *tidev1.Instance, terminalStates ...tidev1.Phase) error {
+func (is *instanceSvc) ensureInstanceReady(
+	ctx context.Context, old *tidev1.Instance, terminalStates ...tidev1.Phase,
+) error {
 	var createdInst *tidev1.Instance
 	var err error
 
 	stateMap := make(map[tidev1.Phase]struct{})
 	for _, state := range terminalStates {
 		stateMap[state] = struct{}{}
-	}
-
-	createdInst, err = is.client.GetInstance(ctx, old.Name, old.Namespace)
-	if err != nil {
-		return errorDom.Raise(ctx, errorDom.ErrInstanceCreationFailed, "failed to get created instance", err, nil)
 	}
 
 	for {

--- a/oracle/external/instance/instance.go
+++ b/oracle/external/instance/instance.go
@@ -34,7 +34,10 @@ func (is *instanceSvc) Start(ctx context.Context, inst *instanceDom.Instance, ma
 	}
 
 	// wait for instance to reach terminal state
-	if err := is.ensureInstanceReady(ctx, tideInstance, tidev1.PhaseRunning, tidev1.PhaseStaged, tidev1.PhaseFailed, tidev1.PhaseExpired, tidev1.PhaseTerminated); err != nil {
+	if err := is.ensureInstanceReady(
+		ctx, tideInstance,
+		tidev1.PhaseRunning, tidev1.PhaseStaged, tidev1.PhaseFailed, tidev1.PhaseExpired, tidev1.PhaseTerminated,
+	); err != nil {
 		return err
 	}
 

--- a/oracle/infra/cache/cache.go
+++ b/oracle/infra/cache/cache.go
@@ -60,7 +60,8 @@ func (c *cache) WithTrace(ctx context.Context, operation string, key string) (co
 func NewClient(ctx context.Context, client valkey.Client) (Cache, error) {
 	var err error
 
-	tracer := otel.GetTracerProvider().Tracer("api.cache", trace.WithInstrumentationAttributes(attribute.String("cache.provider", "valkey")))
+	instAttr := trace.WithInstrumentationAttributes(attribute.String("cache.provider", "valkey"))
+	tracer := otel.GetTracerProvider().Tracer("api.cache", instAttr)
 
 	cache := &cache{
 		client: client,

--- a/oracle/infra/cache/implementation.go
+++ b/oracle/infra/cache/implementation.go
@@ -137,7 +137,8 @@ func (c *cache) SetManyWithExpiry(ctx context.Context, items map[string]string, 
 	}
 	args = append(args, strconv.FormatInt(expiresAt.Unix(), 10))
 
-	if err := c.client.Do(ctx, c.client.B().Evalsha().Sha1(setManyScriptHash).Numkeys(int64(len(keys))).Key(keys...).Arg(args...).Build()).Error(); err != nil {
+	cmd := c.client.B().Evalsha().Sha1(setManyScriptHash).Numkeys(int64(len(keys))).Key(keys...).Arg(args...).Build()
+	if err := c.client.Do(ctx, cmd).Error(); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return errorDom.Raise(ctx, errorDom.ErrCacheCallFail, "", err, nil)
@@ -150,7 +151,8 @@ func (c *cache) ZIncrBy(ctx context.Context, key string, increment float64, memb
 	ctx, span := c.WithTrace(ctx, "zincrby", key)
 	defer span.End()
 
-	if err := c.client.Do(ctx, c.client.B().Zincrby().Key(key).Increment(increment).Member(member).Build()).Error(); err != nil {
+	cmd := c.client.B().Zincrby().Key(key).Increment(increment).Member(member).Build()
+	if err := c.client.Do(ctx, cmd).Error(); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return errorDom.Raise(ctx, errorDom.ErrCacheCallFail, "", err, nil)
@@ -181,7 +183,8 @@ func (c *cache) ZRevRangeWithScores(ctx context.Context, key string, start, stop
 	ctx, span := c.WithTrace(ctx, "zrevrange", key)
 	defer span.End()
 
-	result, err := c.client.Do(ctx, c.client.B().Zrevrange().Key(key).Start(start).Stop(stop).Withscores().Build()).AsZScores()
+	cmd := c.client.B().Zrevrange().Key(key).Start(start).Stop(stop).Withscores().Build()
+	result, err := c.client.Do(ctx, cmd).AsZScores()
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -220,7 +223,9 @@ func (c *cache) ZRevRank(ctx context.Context, key string, member string) (int64,
 	result, err := c.client.Do(ctx, c.client.B().Zrevrank().Key(key).Member(member).Build()).AsInt64()
 	if err != nil {
 		if err == valkey.Nil {
-			return 0, errorDom.Raise(ctx, errorDom.ErrCacheZSetMissingMember, "", err, common.ExtraData{"key": key, "member": member})
+			return 0, errorDom.Raise(ctx, errorDom.ErrCacheZSetMissingMember, "", err, common.ExtraData{
+				"key": key, "member": member,
+			})
 		}
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -237,7 +242,9 @@ func (c *cache) ZScore(ctx context.Context, key string, member string) (float64,
 	result, err := c.client.Do(ctx, c.client.B().Zscore().Key(key).Member(member).Build()).AsFloat64()
 	if err != nil {
 		if err == valkey.Nil {
-			return 0, errorDom.Raise(ctx, errorDom.ErrCacheZSetMissingMember, "", err, common.ExtraData{"key": key, "member": member})
+			return 0, errorDom.Raise(ctx, errorDom.ErrCacheZSetMissingMember, "", err, common.ExtraData{
+				"key": key, "member": member,
+			})
 		}
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/oracle/infra/infra.go
+++ b/oracle/infra/infra.go
@@ -17,13 +17,13 @@ type Infra struct {
 
 func New(ctx context.Context, valkeyClient valkey.Client) (*Infra, error) {
 	config := utils.GetConfig()
-	cnc, err := cnc.NewCNC(ctx, valkeyClient)
+	cncSvc, err := cnc.NewCNC(ctx, valkeyClient)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Infra{
 		JWT: jwt.NewJWT(config.Token.SigningKey),
-		CNC: cnc,
+		CNC: cncSvc,
 	}, nil
 }

--- a/oracle/infra/k8s/k8s.go
+++ b/oracle/infra/k8s/k8s.go
@@ -47,9 +47,9 @@ func NewK8sClient() (client.Client, error) {
 
 	// skip TLS verification for dev environments
 	if utils.GetConfig().K8s.InsecureSkipVerify {
-		config.TLSClientConfig.Insecure = true
-		config.TLSClientConfig.CAData = nil
-		config.TLSClientConfig.CAFile = ""
+		config.Insecure = true
+		config.CAData = nil
+		config.CAFile = ""
 	}
 
 	scheme := runtime.NewScheme()

--- a/oracle/infra/smtp/smtp.go
+++ b/oracle/infra/smtp/smtp.go
@@ -16,6 +16,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const smtpRecipientsKey = "recipients"
+
 type smtpImpl struct {
 	config   *Config
 	sender   gomail.SendCloser
@@ -41,11 +43,11 @@ func (s *smtpImpl) SendAsync(ctx context.Context, email *emailDom.Email) error {
 
 	select {
 	case <-s.ctx.Done():
-		return errorDom.Raise(ctx, errorDom.ErrSMTPContextCanceled, "", nil, common.ExtraData{"recipients": recipients})
+		return errorDom.Raise(ctx, errorDom.ErrSMTPContextCanceled, "", nil, common.ExtraData{smtpRecipientsKey: recipients})
 	case s.messages <- message:
 		return nil
 	default:
-		return errorDom.Raise(ctx, errorDom.ErrSMTPQueueFull, "", nil, common.ExtraData{"recipients": recipients})
+		return errorDom.Raise(ctx, errorDom.ErrSMTPQueueFull, "", nil, common.ExtraData{smtpRecipientsKey: recipients})
 	}
 }
 
@@ -73,7 +75,9 @@ func (s *smtpImpl) sendEmail(message *gomail.Message) error {
 	}
 	err = gomail.Send(sender, message)
 	if err != nil {
-		return errorDom.Raise(s.ctx, errorDom.ErrSMTPSendFailed, "", err, common.ExtraData{"recipients": message.GetHeader("To"), "subject": message.GetHeader("Subject")})
+		return errorDom.Raise(s.ctx, errorDom.ErrSMTPSendFailed, "", err, common.ExtraData{
+			smtpRecipientsKey: message.GetHeader("To"), "subject": message.GetHeader("Subject"),
+		})
 	}
 	return nil
 }
@@ -103,12 +107,7 @@ func (s *smtpImpl) handleEmail(message *gomail.Message) {
 	errorDom.RaiseToSentry(s.ctx, err)
 }
 
-func (s *smtpImpl) start() error {
-	// DEBUG
-	// if _, err := s.getSender(); err != nil {
-	// 	return err
-	// }
-
+func (s *smtpImpl) start() {
 	go func() {
 		resetChan := make(chan struct{}, 1)
 		timer := time.NewTimer(s.config.ConnTimeout)
@@ -140,7 +139,6 @@ func (s *smtpImpl) start() error {
 			}
 		}
 	}()
-	return nil
 }
 
 func (s *smtpImpl) closeSender() {
@@ -167,9 +165,7 @@ func NewSMTP(ctx context.Context, config *Config, wg *sync.WaitGroup) (SMTP, err
 		wg:       wg,
 	}
 
-	if err := smtp.start(); err != nil {
-		return nil, err
-	}
+	smtp.start()
 
 	utils.InterruptHandlerChannel <- func() {
 		cancel()

--- a/oracle/internal/domain/configvars/configvars.go
+++ b/oracle/internal/domain/configvars/configvars.go
@@ -13,7 +13,7 @@ var (
 	EventEnd       = ConfigKey[int]{Name: "event_end", Default: 1710028800}
 	EventPostMode  = ConfigKey[bool]{Name: "event_post_mode", Default: false}
 
-	//smtp
+	// smtp
 	SMTPHost     = ConfigKey[string]{Name: "smtp_host", Default: "smtp.isolet.dev"}
 	SMTPPort     = ConfigKey[int]{Name: "smtp_port", Default: 587}
 	SMTPUser     = ConfigKey[string]{Name: "smtp_user", Default: "user@isolet.dev"}

--- a/oracle/internal/domain/errors/helper.go
+++ b/oracle/internal/domain/errors/helper.go
@@ -88,7 +88,7 @@ func HandleSpanError(ctx context.Context, span trace.Span, log *zap.Logger, msg 
 	span.SetStatus(codes.Error, msg)
 	RaiseToSentry(ctx, err)
 
-	zapFields := []zap.Field{zap.Error(err)}
+	zapFields := append(make([]zap.Field, 0, 1+len(extraFields)), zap.Error(err))
 	zapFields = append(zapFields, extraFields...)
 	log.Error(msg, zapFields...)
 }

--- a/oracle/internal/domain/errors/stack.go
+++ b/oracle/internal/domain/errors/stack.go
@@ -18,11 +18,11 @@ func GetStackTrace() string {
 
 	for {
 		frame, more := frames.Next()
-		sb.WriteString(fmt.Sprintf(
+		fmt.Fprintf(&sb,
 			"\t-> %s:%d (%s)\n",
 			frame.File, frame.Line,
 			path.Base(frame.Function),
-		))
+		)
 		if !more {
 			break
 		}

--- a/oracle/internal/repository/cache/cache.go
+++ b/oracle/internal/repository/cache/cache.go
@@ -12,11 +12,11 @@ import (
 	"github.com/vmihailenco/msgpack/v5"
 )
 
-func CachedQuery[T any](ctx context.Context, cache cache.Cache, key string, ttl time.Duration, fetchFn func() (T, error)) (T, error) {
+func CachedQuery[T any](ctx context.Context, c cache.Cache, key string, ttl time.Duration, fetchFn func() (T, error)) (T, error) {
 	var zero T
 
 	// look in cache
-	val, err := cache.Get(ctx, key)
+	val, err := c.Get(ctx, key)
 	if err != nil {
 		if !errorDom.Is(err, errorDom.ErrCacheMiss) {
 			return zero, err
@@ -36,7 +36,7 @@ func CachedQuery[T any](ctx context.Context, cache cache.Cache, key string, ttl 
 	if err != nil {
 		return zero, err
 	}
-	if err := cache.SetWithTTL(ctx, key, serialized, ttl); err != nil {
+	if err := c.SetWithTTL(ctx, key, serialized, ttl); err != nil {
 		return zero, err
 	}
 

--- a/oracle/internal/repository/challenge/challenge.go
+++ b/oracle/internal/repository/challenge/challenge.go
@@ -109,7 +109,7 @@ func (challengeRepo *challengeRepo) GetUnlockedHints(ctx context.Context, teamID
 	var rows []*UnlockedHint
 
 	if err := challengeRepo.db.WithContext(ctx).Select("hint_id").Where("team_id = ?", teamID).Find(&rows).Error; err != nil {
-		return nil, errorDom.Raise(ctx, errorDom.ErrDBReadError, "failed to retrieve unlocked hints", err, common.ExtraData{"team_id": teamID})
+		return nil, errorDom.Raise(ctx, errorDom.ErrDBReadError, "failed to retrieve unlocked hints", err, common.ExtraData{utils.ContextKeyTeamID: teamID})
 	}
 
 	for _, row := range rows {
@@ -154,7 +154,7 @@ func (challengeRepo *challengeRepo) UnlockHint(ctx context.Context, uHint *chall
 				return errorDom.Raise(ctx, errorDom.ErrHintAlreadyUnlocked, "", nil, nil)
 			}
 		}
-		return errorDom.Raise(ctx, errorDom.ErrDBExecError, "failed to unlock hint", res.Error, common.ExtraData{"team_id": uHintModel.TeamID, "hint_id": uHintModel.HintID})
+		return errorDom.Raise(ctx, errorDom.ErrDBExecError, "failed to unlock hint", res.Error, common.ExtraData{utils.ContextKeyTeamID: uHintModel.TeamID, "hint_id": uHintModel.HintID})
 	}
 
 	if res.RowsAffected == 0 {
@@ -170,7 +170,7 @@ func (challengeRepo *challengeRepo) GetTeamSubmissions(ctx context.Context, team
 
 	err := challengeRepo.db.WithContext(ctx).Where("team_id = ?", teamID).Find(&submissions).Error
 	if err != nil {
-		return nil, errorDom.Raise(ctx, errorDom.ErrDBReadError, "failed to retrieve submissions", err, common.ExtraData{"team_id": teamID})
+		return nil, errorDom.Raise(ctx, errorDom.ErrDBReadError, "failed to retrieve submissions", err, common.ExtraData{utils.ContextKeyTeamID: teamID})
 	}
 
 	for _, submission := range submissions {
@@ -184,9 +184,9 @@ func (challengeRepo *challengeRepo) GetTeamSubmissions(ctx context.Context, team
 	return result, nil
 }
 
-func New(db *gorm.DB, cache cache.Cache) challengeDom.Repository {
+func New(db *gorm.DB, c cache.Cache) challengeDom.Repository {
 	return &challengeRepo{
 		db:    db,
-		cache: cache,
+		cache: c,
 	}
 }

--- a/oracle/internal/repository/instance/instance.go
+++ b/oracle/internal/repository/instance/instance.go
@@ -8,6 +8,7 @@ import (
 	"github.com/TheAlpha16/isolet/oracle/internal/domain/common"
 	errorDom "github.com/TheAlpha16/isolet/oracle/internal/domain/errors"
 	instanceDom "github.com/TheAlpha16/isolet/oracle/internal/domain/instance"
+	"github.com/TheAlpha16/isolet/oracle/utils"
 
 	"github.com/jackc/pgx/v5/pgconn"
 	"gorm.io/gorm"
@@ -19,7 +20,7 @@ type instanceRepo struct {
 }
 
 func (ir *instanceRepo) Create(ctx context.Context, instance *instanceDom.Instance) (*instanceDom.Instance, error) {
-	extraData := common.ExtraData{"team_id": instance.TeamID, "challenge_id": instance.ChallengeID}
+	extraData := common.ExtraData{utils.ContextKeyTeamID: instance.TeamID, utils.ContextKeyChallengeID: instance.ChallengeID}
 	instanceModel, err := NewInstanceModel(instance)
 	if err != nil {
 		return nil, err
@@ -70,7 +71,7 @@ func (ir instanceRepo) Delete(ctx context.Context, id int64) error {
 func (ir *instanceRepo) GetByTeam(ctx context.Context, teamID int64) ([]*instanceDom.Instance, error) {
 	var instances []Instance
 	if err := ir.db.WithContext(ctx).Preload("Endpoints").Where("team_id = ?", teamID).Find(&instances).Error; err != nil {
-		return nil, errorDom.Raise(ctx, errorDom.ErrDBReadError, "failed to get instances by team", err, common.ExtraData{"team_id": teamID})
+		return nil, errorDom.Raise(ctx, errorDom.ErrDBReadError, "failed to get instances by team", err, common.ExtraData{utils.ContextKeyTeamID: teamID})
 	}
 
 	domainInstances := make([]*instanceDom.Instance, 0, len(instances))
@@ -98,7 +99,7 @@ func (ir *instanceRepo) GetByRefs(ctx context.Context, teamID *int64, challengeI
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, errorDom.Raise(ctx, errorDom.ErrInstanceNotFound, "", err, nil)
 		}
-		return nil, errorDom.Raise(ctx, errorDom.ErrDBReadError, "failed to get instance by refs", err, common.ExtraData{"team_id": teamID, "challenge_id": challengeID})
+		return nil, errorDom.Raise(ctx, errorDom.ErrDBReadError, "failed to get instance by refs", err, common.ExtraData{utils.ContextKeyTeamID: teamID, utils.ContextKeyChallengeID: challengeID})
 	}
 
 	return instance.ToDomain(ctx)
@@ -115,7 +116,7 @@ func (ir *instanceRepo) DeleteByRefs(ctx context.Context, teamID *int64, challen
 
 	resp := query.Delete(&Instance{})
 	if err := resp.Error; err != nil {
-		return 0, errorDom.Raise(ctx, errorDom.ErrDBDeleteError, "failed to delete instance by refs", err, common.ExtraData{"team_id": teamID, "challenge_id": challengeID})
+		return 0, errorDom.Raise(ctx, errorDom.ErrDBDeleteError, "failed to delete instance by refs", err, common.ExtraData{utils.ContextKeyTeamID: teamID, utils.ContextKeyChallengeID: challengeID})
 	}
 	return resp.RowsAffected, nil
 }

--- a/oracle/internal/repository/manifest/manifest.go
+++ b/oracle/internal/repository/manifest/manifest.go
@@ -45,9 +45,9 @@ func (manifestRepo *manifestRepo) GetByChallengeID(ctx context.Context, challeng
 	)
 }
 
-func New(db *gorm.DB, cache cache.Cache) manifestDom.Repository {
+func New(db *gorm.DB, c cache.Cache) manifestDom.Repository {
 	return &manifestRepo{
 		db:    db,
-		cache: cache,
+		cache: c,
 	}
 }

--- a/oracle/internal/repository/repository.go
+++ b/oracle/internal/repository/repository.go
@@ -30,23 +30,23 @@ type Repositories struct {
 	Manifest   manifestDom.Repository
 }
 
-func New(db *gorm.DB, cache cache.Cache) *Repositories {
-	userRepo := userRepo.New(db)
-	teamRepo := teamRepo.New(db)
-	cvRepo := cvRepo.New(db)
-	challengeRepo := challengeRepo.New(db, cache)
-	scoreRepo := scoreRepo.New(db)
-	instanceRepo := instanceRepo.New(db)
-	manifestRepo := manifestRepo.New(db, cache)
+func New(db *gorm.DB, cacheClient cache.Cache) *Repositories {
+	users := userRepo.New(db)
+	teams := teamRepo.New(db)
+	cv := cvRepo.New(db)
+	challenges := challengeRepo.New(db, cacheClient)
+	scores := scoreRepo.New(db)
+	instances := instanceRepo.New(db)
+	manifests := manifestRepo.New(db, cacheClient)
 
 	return &Repositories{
-		User:       userRepo,
-		Team:       teamRepo,
-		ConfigVars: cvRepo,
-		Challenge:  challengeRepo,
-		Score:      scoreRepo,
-		Instance:   instanceRepo,
-		Manifest:   manifestRepo,
+		User:       users,
+		Team:       teams,
+		ConfigVars: cv,
+		Challenge:  challenges,
+		Score:      scores,
+		Instance:   instances,
+		Manifest:   manifests,
 	}
 }
 

--- a/oracle/internal/repository/score/score.go
+++ b/oracle/internal/repository/score/score.go
@@ -7,6 +7,7 @@ import (
 	errorDom "github.com/TheAlpha16/isolet/oracle/internal/domain/errors"
 	scoreDom "github.com/TheAlpha16/isolet/oracle/internal/domain/score"
 	challengeRepo "github.com/TheAlpha16/isolet/oracle/internal/repository/challenge"
+	"github.com/TheAlpha16/isolet/oracle/utils"
 
 	"github.com/lib/pq"
 	"gorm.io/gorm"
@@ -25,7 +26,7 @@ func (scoreRepo *scoreRepo) GetSubmissionStats(ctx context.Context, teamID int64
 	}
 
 	if err := scoreRepo.db.WithContext(ctx).Raw("SELECT challenge_id, COUNT(*) FILTER (WHERE is_correct = true)  AS correct_count, COUNT(*) FILTER (WHERE is_correct = false) AS incorrect_count FROM submissions WHERE team_id = ? AND challenge_id IN ? GROUP BY challenge_id", teamID, challengeIDs).Scan(&rows).Error; err != nil {
-		return nil, errorDom.Raise(ctx, errorDom.ErrDBReadError, "failed to retrieve submission stats", err, common.ExtraData{"team_id": teamID, "challenge_ids": challengeIDs})
+		return nil, errorDom.Raise(ctx, errorDom.ErrDBReadError, "failed to retrieve submission stats", err, common.ExtraData{utils.ContextKeyTeamID: teamID, "challenge_ids": challengeIDs})
 	}
 
 	for _, row := range rows {
@@ -62,7 +63,7 @@ func (scoreRepo *scoreRepo) GetTeamSolves(ctx context.Context, teamID int64) (ma
 	var rows []*challengeRepo.Solve
 
 	if err := scoreRepo.db.WithContext(ctx).Select("challenge_id").Where("team_id = ?", teamID).Find(&rows).Error; err != nil {
-		return nil, errorDom.Raise(ctx, errorDom.ErrDBReadError, "failed to retrieve team solves", err, common.ExtraData{"team_id": teamID})
+		return nil, errorDom.Raise(ctx, errorDom.ErrDBReadError, "failed to retrieve team solves", err, common.ExtraData{utils.ContextKeyTeamID: teamID})
 	}
 
 	for _, row := range rows {
@@ -76,7 +77,7 @@ func (scoreRepo *scoreRepo) GetTeamScore(ctx context.Context, teamID int64) (int
 	var score int
 
 	if err := scoreRepo.db.WithContext(ctx).Raw("SELECT COALESCE((SELECT SUM(points) FROM solves WHERE team_id = ?), 0) - COALESCE((SELECT SUM(cost) FROM unlocked_hints WHERE team_id = ?), 0) AS score;", teamID, teamID).Scan(&score).Error; err != nil {
-		return 0, errorDom.Raise(ctx, errorDom.ErrDBReadError, "failed to retrieve team score", err, common.ExtraData{"team_id": teamID})
+		return 0, errorDom.Raise(ctx, errorDom.ErrDBReadError, "failed to retrieve team score", err, common.ExtraData{utils.ContextKeyTeamID: teamID})
 	}
 
 	return score, nil

--- a/oracle/internal/usecase/auth/auth.go
+++ b/oracle/internal/usecase/auth/auth.go
@@ -16,6 +16,12 @@ import (
 	"github.com/TheAlpha16/isolet/oracle/utils"
 )
 
+const (
+	tokenMetadataEmail    = "email"
+	tokenMetadataUsername = "username"
+	tokenMetadataPassword = "password"
+)
+
 type authImpl struct {
 	userUc  userDom.Usecase
 	tokenUc tokenDom.Usecase
@@ -75,7 +81,7 @@ func (a *authImpl) Register(ctx context.Context, input *authDom.RegisterInput) (
 	// hash the password
 	hashedPassword, err := utils.HashPassword(input.Password)
 	if err != nil {
-		return nil, errorDom.RaiseInternal(ctx, "failed to hash password", err, common.ExtraData{"password": input.Password})
+		return nil, errorDom.RaiseInternal(ctx, "failed to hash password", err, common.ExtraData{tokenMetadataPassword: input.Password})
 	}
 	input.Password = hashedPassword
 
@@ -152,13 +158,13 @@ func (a *authImpl) Verify(ctx context.Context, verifyToken string) error {
 
 	var email, username, password string
 	var ok bool
-	if email, ok = token.Metadata["email"]; !ok {
+	if email, ok = token.Metadata[tokenMetadataEmail]; !ok {
 		return errorDom.Raise(ctx, errorDom.ErrTokenExpiredInvalid, "", nil, nil)
 	}
-	if username, ok = token.Metadata["username"]; !ok {
+	if username, ok = token.Metadata[tokenMetadataUsername]; !ok {
 		return errorDom.Raise(ctx, errorDom.ErrTokenExpiredInvalid, "", nil, nil)
 	}
-	if password, ok = token.Metadata["password"]; !ok {
+	if password, ok = token.Metadata[tokenMetadataPassword]; !ok {
 		return errorDom.Raise(ctx, errorDom.ErrTokenExpiredInvalid, "", nil, nil)
 	}
 
@@ -231,7 +237,7 @@ func (a *authImpl) ResetPassword(ctx context.Context, input *authDom.ResetPasswo
 	// hash the password
 	hashedPassword, err := utils.HashPassword(input.Password)
 	if err != nil {
-		return errorDom.RaiseInternal(ctx, "failed to hash password", err, common.ExtraData{"password": input.Password})
+		return errorDom.RaiseInternal(ctx, "failed to hash password", err, common.ExtraData{tokenMetadataPassword: input.Password})
 	}
 	input.Password = hashedPassword
 
@@ -347,9 +353,9 @@ func (a *authImpl) generateEmailVerificationToken(ctx context.Context, email, us
 			Purpose:  tokenDom.TokenEmailVerification,
 		},
 		Metadata: map[string]string{
-			"email":    email,
-			"username": username,
-			"password": password,
+			tokenMetadataEmail:    email,
+			tokenMetadataUsername: username,
+			tokenMetadataPassword: password,
 		},
 	}
 	token.UpdateTime()

--- a/oracle/internal/usecase/configvars/configvars.go
+++ b/oracle/internal/usecase/configvars/configvars.go
@@ -122,14 +122,14 @@ func parseOrDefault[T any](ctx context.Context, cv *cvImpl, key cvDom.ConfigKey[
 	return key.Default
 }
 
-func New(ctx context.Context, repo cvDom.Repository, cnc cnc.CNC) cvDom.Usecase {
+func New(ctx context.Context, repo cvDom.Repository, cncSvc cnc.CNC) cvDom.Usecase {
 	config := utils.GetConfig()
 	ctx, cancel := context.WithCancel(ctx)
 
 	cv := &cvImpl{
 		repo:   repo,
 		cache:  make(map[string]string),
-		cnc:    cnc,
+		cnc:    cncSvc,
 		mu:     sync.RWMutex{},
 		ctx:    ctx,
 		cancel: cancel,

--- a/oracle/internal/usecase/email/email.go
+++ b/oracle/internal/usecase/email/email.go
@@ -87,13 +87,13 @@ func (e *emailImpl) SendEmailAsync(ctx context.Context, input *emailDom.EmailInp
 }
 
 func (e *emailImpl) getBody(ctx context.Context, templatePath string, data *emailDom.TemplateInput) (string, error) {
-	template, err := template.ParseFS(templateFS, templatePath)
+	tmpl, err := template.ParseFS(templateFS, templatePath)
 	if err != nil {
 		return "", errorDom.Raise(ctx, errorDom.ErrEmailTemplateFetch, "", err, common.ExtraData{"path": templatePath})
 	}
 
 	var buf bytes.Buffer
-	if err := template.Execute(&buf, data); err != nil {
+	if err := tmpl.Execute(&buf, data); err != nil {
 		return "", errorDom.Raise(ctx, errorDom.ErrEmailTemplateExecute, "", err, common.ExtraData{"path": templatePath})
 	}
 

--- a/oracle/internal/usecase/instance/instance.go
+++ b/oracle/internal/usecase/instance/instance.go
@@ -325,13 +325,13 @@ func (i *instanceImpl) runInstanceExpiryCleanup(ctx context.Context, interval ti
 	})
 }
 
-func New(ctx context.Context, repo instanceDom.Repository, service instanceDom.Service, cache cache.Cache, challengeUc challengeDom.Usecase, manifestUc manifestDom.Usecase, cvUc cvDom.Usecase, wg *sync.WaitGroup) instanceDom.Usecase {
+func New(ctx context.Context, repo instanceDom.Repository, service instanceDom.Service, c cache.Cache, challengeUc challengeDom.Usecase, manifestUc manifestDom.Usecase, cvUc cvDom.Usecase, wg *sync.WaitGroup) instanceDom.Usecase {
 	ctx, cancel := context.WithCancel(ctx)
 
 	inst := &instanceImpl{
 		repo:        repo,
 		service:     service,
-		cache:       cache,
+		cache:       c,
 		challengeUc: challengeUc,
 		manifestUc:  manifestUc,
 		cvUc:        cvUc,

--- a/oracle/internal/usecase/profile/profile.go
+++ b/oracle/internal/usecase/profile/profile.go
@@ -100,11 +100,11 @@ func (p *profileImpl) getTeamScoreAndRank(ctx context.Context, teamID int64) (ra
 	return int(teamScore), int(teamRank), nil
 }
 
-func New(cache cache.Cache, userUc userDom.Usecase, teamUc teamDom.Usecase, challengeUc challengeDom.Usecase) profileDom.Usecase {
+func New(c cache.Cache, userUc userDom.Usecase, teamUc teamDom.Usecase, challengeUc challengeDom.Usecase) profileDom.Usecase {
 	return &profileImpl{
 		userUc:      userUc,
 		teamUc:      teamUc,
 		challengeUc: challengeUc,
-		cache:       cache,
+		cache:       c,
 	}
 }

--- a/oracle/internal/usecase/score/score.go
+++ b/oracle/internal/usecase/score/score.go
@@ -192,11 +192,11 @@ func (scoreImpl *scoreImpl) getScoreboardEntries(ctx context.Context, start, sto
 	return entries, teamIDs, nil
 }
 
-func New(repo scoreDom.Repository, teamUc teamDom.Usecase, cache cache.Cache) scoreDom.Usecase {
+func New(repo scoreDom.Repository, teamUc teamDom.Usecase, c cache.Cache) scoreDom.Usecase {
 	scoreImpl := &scoreImpl{
 		repo:   repo,
 		teamUc: teamUc,
-		cache:  cache,
+		cache:  c,
 	}
 	err := scoreImpl.RefreshScoreboard(context.Background())
 	if err != nil {

--- a/oracle/internal/usecase/token/token.go
+++ b/oracle/internal/usecase/token/token.go
@@ -108,8 +108,8 @@ func (t *tokenImpl) FetchEntityTokens(ctx context.Context, purpose tokenDom.Toke
 	return tokens, nil
 }
 
-func New(cache cache.Cache) tokenDom.Usecase {
+func New(c cache.Cache) tokenDom.Usecase {
 	return &tokenImpl{
-		cache: cache,
+		cache: c,
 	}
 }

--- a/oracle/internal/usecase/usecase.go
+++ b/oracle/internal/usecase/usecase.go
@@ -52,22 +52,22 @@ type Usecases struct {
 	Manifest   manifestDom.Usecase
 }
 
-func New(ctx context.Context, wg *sync.WaitGroup, cache cache.Cache, repos *repository.Repositories, infra *infra.Infra, external *external.Services) *Usecases {
+func New(ctx context.Context, wg *sync.WaitGroup, c cache.Cache, repos *repository.Repositories, svc *infra.Infra, ext *external.Services) *Usecases {
 	// helpers
-	cv := cvUc.New(ctx, repos.ConfigVars, infra.CNC)
-	token := tokenUc.New(cache)
+	cv := cvUc.New(ctx, repos.ConfigVars, svc.CNC)
+	token := tokenUc.New(c)
 	email := emailUc.New(ctx, wg, cv)
 
 	// business
-	user := userUc.New(cache, repos.User, cv)
-	auth := authUc.New(user, token, cv, email, infra.JWT)
-	team := teamUc.New(repos.Team, user, auth, token, cv, infra.JWT)
+	user := userUc.New(c, repos.User, cv)
+	auth := authUc.New(user, token, cv, email, svc.JWT)
+	team := teamUc.New(repos.Team, user, auth, token, cv, svc.JWT)
 	event := eventUc.New(cv)
-	score := scoreUc.New(repos.Score, team, cache)
+	score := scoreUc.New(repos.Score, team, c)
 	challenge := challengeUc.New(repos.Challenge, repos.Instance, cv, score, wg)
-	profile := profileUc.New(cache, user, team, challenge)
+	profile := profileUc.New(c, user, team, challenge)
 	manifest := manifestUc.New(repos.Manifest)
-	instance := instanceUc.New(ctx, repos.Instance, external.Instance, cache, challenge, manifest, cv, wg)
+	instance := instanceUc.New(ctx, repos.Instance, ext.Instance, c, challenge, manifest, cv, wg)
 	fact := factUc.New(instance)
 
 	return &Usecases{

--- a/oracle/internal/usecase/user/user.go
+++ b/oracle/internal/usecase/user/user.go
@@ -77,10 +77,10 @@ func (u *userImpl) JoinTeam(ctx context.Context, userID int64, teamID int64) err
 	)
 }
 
-func New(cache cache.Cache, repo userDom.Repository, cvUc cvDom.Usecase) userDom.Usecase {
+func New(c cache.Cache, repo userDom.Repository, cvUc cvDom.Usecase) userDom.Usecase {
 	return &userImpl{
 		repo:  repo,
-		cache: cache,
+		cache: c,
 		cvUc:  cvUc,
 	}
 }

--- a/oracle/main.go
+++ b/oracle/main.go
@@ -56,7 +56,7 @@ func main() {
 	}
 
 	// Init cache
-	cache, err := cache.NewClient(ctx, valkeyClient)
+	cacheClient, err := cache.NewClient(ctx, valkeyClient)
 	if err != nil {
 		errorDom.RaiseToSentry(ctx, err)
 		appLogger.Fatal("failed to connect to cache", zap.Error(err))
@@ -72,24 +72,24 @@ func main() {
 	}
 
 	// Init infra services
-	infra, err := infra.New(ctx, valkeyClient)
+	infraSvc, err := infra.New(ctx, valkeyClient)
 	if err != nil {
 		errorDom.RaiseToSentry(ctx, err)
 		appLogger.Fatal("failed to initialize infra services", zap.Error(err))
 	}
 
 	// External services
-	external, err := external.New(ctx)
+	externalSvc, err := external.New(ctx)
 	if err != nil {
 		errorDom.RaiseToSentry(ctx, err)
 		appLogger.Fatal("failed to initialize external services", zap.Error(err))
 	}
 
 	// Init repositories
-	repos := repository.New(dbPool, cache)
+	repos := repository.New(dbPool, cacheClient)
 
 	// Init usecases
-	usecases := usecase.New(ctx, &wg, cache, repos, infra, external)
+	usecases := usecase.New(ctx, &wg, cacheClient, repos, infraSvc, externalSvc)
 
 	// Start metrics server
 	metricsServer := metrics.New()
@@ -97,15 +97,17 @@ func main() {
 		metricsServer.Start()
 	})
 	utils.InterruptHandlerChannel <- func() {
-		metricsServer.Shutdown(ctx)
+		if err := metricsServer.Shutdown(ctx); err != nil {
+			appLogger.Error("failed to shut down metrics server", zap.Error(err))
+		}
 	}
 
 	// Start the server based on identity
 	switch utils.GetConfig().Identity {
 	case utils.IdentityRest:
-		StartRestServer(ctx, usecases, infra)
+		StartRestServer(usecases, infraSvc)
 	case utils.IdentityConsumer:
-		StartConsumer(ctx, usecases, infra, &wg)
+		StartConsumer(ctx, usecases, &wg)
 	default:
 		appLogger.Fatal("unknown identity", zap.String("identity", string(utils.GetConfig().Identity)))
 	}
@@ -134,15 +136,15 @@ func ConnectToPostgresDatabase(ctx context.Context) (*gorm.DB, func(), error) {
 	return dbPool, closeConn, nil
 }
 
-func StartRestServer(ctx context.Context, usecases *usecase.Usecases, infra *infra.Infra) {
-	app := restDel.New(usecases, infra)
+func StartRestServer(usecases *usecase.Usecases, svc *infra.Infra) {
+	app := restDel.New(usecases, svc)
 	utils.InterruptHandlerChannel <- func() {
 		restDel.Shutdown(app)
 	}
 	go restDel.StartServer(app)
 }
 
-func StartConsumer(ctx context.Context, usecases *usecase.Usecases, infra *infra.Infra, wg *sync.WaitGroup) {
+func StartConsumer(ctx context.Context, usecases *usecase.Usecases, wg *sync.WaitGroup) {
 	appLogger := logger.GetAppLogger()
 	c, err := consumer.New(ctx, usecases.Fact)
 	if err != nil {

--- a/oracle/utils/constants.go
+++ b/oracle/utils/constants.go
@@ -82,11 +82,12 @@ const (
 
 // context keys
 const (
-	ContextKeyUserID    = "user_id"
-	ContextKeyTeamID    = "team_id"
-	ContextKeyRole      = "role"
-	ContextKeySessionID = "session_id"
-	ContextKeyIP        = "ip"
+	ContextKeyUserID      = "user_id"
+	ContextKeyTeamID      = "team_id"
+	ContextKeyChallengeID = "challenge_id"
+	ContextKeyRole        = "role"
+	ContextKeySessionID   = "session_id"
+	ContextKeyIP          = "ip"
 )
 
 // regular expressions

--- a/oracle/utils/tracer/metrics.go
+++ b/oracle/utils/tracer/metrics.go
@@ -17,13 +17,24 @@ var (
 )
 
 var (
+	LabelChallengeID = "challenge_id"
+	LabelCorrect     = "correct"
+	LabelOperation   = "operation"
+	LabelStatus      = "status"
+	LabelMethod      = "method"
+	LabelRoute       = "route"
+	LabelTopic       = "topic"
+	LabelFactType    = "fact_type"
+)
+
+var (
 	// Challenges
 	FlagSubmissionsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "flag_submissions_total",
 			Help: "Total number of flag submissions",
 		},
-		[]string{"challenge_id", "correct"},
+		[]string{LabelChallengeID, LabelCorrect},
 	)
 
 	// Instances
@@ -32,7 +43,7 @@ var (
 			Name: "instance_operations_total",
 			Help: "Total number of instance operations",
 		},
-		[]string{"challenge_id", "operation", "status"},
+		[]string{LabelChallengeID, LabelOperation, LabelStatus},
 	)
 
 	InstanceProvisionDurationSeconds = promauto.NewHistogramVec(
@@ -40,7 +51,7 @@ var (
 			Name: "instance_provision_duration_seconds",
 			Help: "Time taken to provision an instance",
 		},
-		[]string{"challenge_id", "operation", "status"},
+		[]string{LabelChallengeID, LabelOperation, LabelStatus},
 	)
 
 	// Emails
@@ -49,7 +60,7 @@ var (
 			Name: "emails_sent_total",
 			Help: "Total number of emails sent",
 		},
-		[]string{"status"},
+		[]string{LabelStatus},
 	)
 
 	EmailSendDurationSeconds = promauto.NewHistogramVec(
@@ -57,7 +68,7 @@ var (
 			Name: "email_send_duration_seconds",
 			Help: "Time taken to send email",
 		},
-		[]string{"status"},
+		[]string{LabelStatus},
 	)
 
 	// HTTP
@@ -66,7 +77,7 @@ var (
 			Name: "http_requests_total",
 			Help: "Total number of HTTP requests",
 		},
-		[]string{"method", "route", "status"},
+		[]string{LabelMethod, LabelRoute, LabelStatus},
 	)
 
 	HttpRequestDurationSeconds = promauto.NewHistogramVec(
@@ -74,7 +85,7 @@ var (
 			Name: "http_request_duration_seconds",
 			Help: "Duration of HTTP requests",
 		},
-		[]string{"method", "route"},
+		[]string{LabelMethod, LabelRoute},
 	)
 
 	HttpRequestsInFlight = promauto.NewGaugeVec(
@@ -82,7 +93,7 @@ var (
 			Name: "http_requests_in_flight",
 			Help: "Current number of in-flight HTTP requests",
 		},
-		[]string{"route"},
+		[]string{LabelRoute},
 	)
 
 	// Facts
@@ -91,7 +102,7 @@ var (
 			Name: "facts_total",
 			Help: "Total number of facts processed",
 		},
-		[]string{"topic", "status", "fact_type"},
+		[]string{LabelTopic, LabelStatus, LabelFactType},
 	)
 
 	FactDeliveryDurationSeconds = promauto.NewHistogramVec(
@@ -99,7 +110,7 @@ var (
 			Name: "fact_delivery_duration_seconds",
 			Help: "Time taken to deliver a fact",
 		},
-		[]string{"topic", "fact_type"},
+		[]string{LabelTopic, LabelFactType},
 	)
 
 	FactProcessingDurationSeconds = promauto.NewHistogramVec(
@@ -107,7 +118,7 @@ var (
 			Name: "fact_processing_duration_seconds",
 			Help: "Time taken to process a fact",
 		},
-		[]string{"topic", "fact_type"},
+		[]string{LabelTopic, LabelFactType},
 	)
 )
 

--- a/oracle/utils/tracer/tracing.go
+++ b/oracle/utils/tracer/tracing.go
@@ -24,7 +24,7 @@ func StartSpan(ctx context.Context, tracer trace.Tracer, spanName string) (conte
 }
 
 func Sleep(ctx context.Context, usecase string, duration time.Duration) {
-	ctx, span := sleepTracer.Start(ctx, "sleep."+usecase)
+	_, span := sleepTracer.Start(ctx, "sleep."+usecase)
 	defer span.End()
 	time.Sleep(duration)
 }

--- a/oracle/utils/utils.go
+++ b/oracle/utils/utils.go
@@ -41,7 +41,7 @@ func StructTagsAsString(obj interface{}, tagKey string, depth int) string {
 	}
 
 	t := reflect.TypeOf(obj)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 
@@ -72,21 +72,21 @@ func RandomUUID() string {
 
 // BuildLink constructs a URL with the given public URL, token, and path segments.
 func BuildLink(publicURL, token string, pathSegments []string) (string, error) {
-	url, err := url.Parse(publicURL)
+	parsedURL, err := url.Parse(publicURL)
 	if err != nil {
 		return "", err
 	}
 
-	url = url.JoinPath(pathSegments...)
-	query := url.Query()
+	parsedURL = parsedURL.JoinPath(pathSegments...)
+	query := parsedURL.Query()
 	query.Set(TokenQueryKey, token)
-	url.RawQuery = query.Encode()
+	parsedURL.RawQuery = query.Encode()
 
-	if url.Scheme == "" {
-		url.Scheme = "https"
+	if parsedURL.Scheme == "" {
+		parsedURL.Scheme = "https"
 	}
 
-	return url.String(), nil
+	return parsedURL.String(), nil
 }
 
 // IntOrNil returns a pointer to the integer or nil if the integer is zero.

--- a/tide/.golangci.yml
+++ b/tide/.golangci.yml
@@ -22,6 +22,8 @@ linters:
     - unparam
     - unused
   settings:
+    gocyclo:
+      min-complexity: 60
     revive:
       rules:
         - name: comment-spacings
@@ -36,6 +38,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - linters:
+          - goconst
+        path: .*_test\.go
     paths:
       - third_party$
       - builtin$

--- a/tide/internal/controller/instance_controller.go
+++ b/tide/internal/controller/instance_controller.go
@@ -95,7 +95,7 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	// Ensure finalizer is present for all non-deleted Instances
-	if instance.ObjectMeta.DeletionTimestamp.IsZero() {
+	if instance.DeletionTimestamp.IsZero() {
 		if !controllerutil.ContainsFinalizer(&instance, utils.InstanceFinalizer) {
 			controllerutil.AddFinalizer(&instance, utils.InstanceFinalizer)
 			if err := r.Update(ctx, &instance); err != nil {
@@ -121,7 +121,7 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	// handle deletion
-	if !instance.ObjectMeta.DeletionTimestamp.IsZero() {
+	if !instance.DeletionTimestamp.IsZero() {
 		if instance.Status.Phase != challengesv1.PhaseTerminated {
 			instance.Status.Phase = challengesv1.PhaseTerminated
 			if err := r.Status().Update(ctx, &instance); err != nil {
@@ -158,7 +158,7 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				"namespace", instance.Namespace,
 				"name", instance.Name,
 				"expiresAt", instance.Spec.Lifecycle.ExpiresAt.Time)
-			if err := r.Client.Delete(ctx, &instance); err != nil {
+			if err := r.Delete(ctx, &instance); err != nil {
 				log.Error(err, "Failed to delete expired Instance", "namespace", instance.Namespace, "name", instance.Name)
 				return ctrl.Result{}, err
 			}
@@ -179,7 +179,7 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 			Type:    utils.ConditionDeploymentReady,
 			Status:  metav1.ConditionFalse,
-			Reason:  "ReconciliationFailed",
+			Reason:  utils.ReasonReconciliationFailed,
 			Message: err.Error(),
 		})
 		statusChanged = true
@@ -197,17 +197,15 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			// Deployment is not ready, check for Pod failures
 			failed, failureReason, message := r.checkPodFailures(ctx, &instance)
 			if failed {
-				if meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+				meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 					Type:    utils.ConditionDeploymentReady,
 					Status:  metav1.ConditionFalse,
 					Reason:  failureReason,
 					Message: message,
-				}) {
-					statusChanged = true
-				}
+				})
 				// Force phase update to Failed
 				instance.Status.Phase = challengesv1.PhaseFailed
-				statusChanged = true // Ensure we trigger status update
+				statusChanged = true
 			} else {
 				if meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 					Type:    utils.ConditionDeploymentReady,
@@ -228,7 +226,7 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 			Type:    utils.ConditionServiceReady,
 			Status:  metav1.ConditionFalse,
-			Reason:  "ReconciliationFailed",
+			Reason:  utils.ReasonReconciliationFailed,
 			Message: err.Error(),
 		})
 		statusChanged = true
@@ -261,7 +259,7 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 			Type:    utils.ConditionIngressReady,
 			Status:  metav1.ConditionFalse,
-			Reason:  "ReconciliationFailed",
+			Reason:  utils.ReasonReconciliationFailed,
 			Message: err.Error(),
 		})
 		statusChanged = true
@@ -404,9 +402,9 @@ func (r *InstanceReconciler) reconcileDeployment(ctx context.Context, instance *
 			Labels: map[string]string{
 				// standard labels
 				utils.LabelAppName:      instance.Name,
-				utils.LabelAppPartOf:    "instance",
-				utils.LabelAppManagedBy: "tide-controller",
-				utils.LabelAppComponent: "deployment",
+				utils.LabelAppPartOf:    utils.LabelValInstance,
+				utils.LabelAppManagedBy: utils.LabelValTideController,
+				utils.LabelAppComponent: utils.LabelValDeployment,
 
 				// tide specific labels
 				utils.LabelChallengeID:   instance.Name,
@@ -417,7 +415,7 @@ func (r *InstanceReconciler) reconcileDeployment(ctx context.Context, instance *
 					if instance.Spec.Team != nil {
 						return strconv.FormatInt(instance.Spec.Team.ID, 10)
 					}
-					return "dynamic"
+					return utils.TeamDynamic
 				}(),
 			},
 		},
@@ -425,7 +423,7 @@ func (r *InstanceReconciler) reconcileDeployment(ctx context.Context, instance *
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					utils.LabelAppName:      instance.Name,
-					utils.LabelAppComponent: "deployment",
+					utils.LabelAppComponent: utils.LabelValDeployment,
 					utils.LabelChallengeID:  instance.Name,
 				},
 			},
@@ -433,7 +431,7 @@ func (r *InstanceReconciler) reconcileDeployment(ctx context.Context, instance *
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						utils.LabelAppName:      instance.Name,
-						utils.LabelAppComponent: "deployment",
+						utils.LabelAppComponent: utils.LabelValDeployment,
 						utils.LabelChallengeID:  instance.Name,
 					},
 				},
@@ -453,7 +451,7 @@ func (r *InstanceReconciler) reconcileDeployment(ctx context.Context, instance *
 								return envs
 							}(),
 							Ports: func() []corev1.ContainerPort {
-								var ports []corev1.ContainerPort
+								ports := make([]corev1.ContainerPort, 0, len(instance.Spec.Endpoints))
 								for _, ep := range instance.Spec.Endpoints {
 									ports = append(ports, corev1.ContainerPort{
 										Name:          ep.Name,
@@ -516,8 +514,8 @@ func (r *InstanceReconciler) reconcileService(ctx context.Context, instance *cha
 			Labels: map[string]string{
 				// standard labels
 				utils.LabelAppName:      instance.Name,
-				utils.LabelAppPartOf:    "instance",
-				utils.LabelAppManagedBy: "tide-controller",
+				utils.LabelAppPartOf:    utils.LabelValInstance,
+				utils.LabelAppManagedBy: utils.LabelValTideController,
 				utils.LabelAppComponent: "service",
 
 				// tide specific labels
@@ -529,14 +527,14 @@ func (r *InstanceReconciler) reconcileService(ctx context.Context, instance *cha
 					if instance.Spec.Team != nil {
 						return strconv.FormatInt(instance.Spec.Team.ID, 10)
 					}
-					return "dynamic"
+					return utils.TeamDynamic
 				}(),
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
 				utils.LabelAppName:      instance.Name,
-				utils.LabelAppComponent: "deployment",
+				utils.LabelAppComponent: utils.LabelValDeployment,
 			},
 			Type: corev1.ServiceTypeClusterIP,
 		},
@@ -705,8 +703,8 @@ func (r *InstanceReconciler) reconcileIngressRoute(ctx context.Context, instance
 			Labels: map[string]string{
 				// standard labels
 				"app.kubernetes.io/name":       instance.Name,
-				"app.kubernetes.io/part-of":    "instance",
-				"app.kubernetes.io/managed-by": "tide-controller",
+				"app.kubernetes.io/part-of":    utils.LabelValInstance,
+				"app.kubernetes.io/managed-by": utils.LabelValTideController,
 				"app.kubernetes.io/component":  "ingress",
 
 				// tide specific labels
@@ -718,12 +716,12 @@ func (r *InstanceReconciler) reconcileIngressRoute(ctx context.Context, instance
 					if instance.Spec.Team != nil {
 						return strconv.FormatInt(instance.Spec.Team.ID, 10)
 					}
-					return "dynamic"
+					return utils.TeamDynamic
 				}(),
 			},
 		},
 		Spec: traefikv1alpha1.IngressRouteSpec{
-			EntryPoints: []string{"web", "websecure"},
+			EntryPoints: []string{utils.EntryPointWeb, utils.EntryPointWebsecure},
 			TLS: &traefikv1alpha1.TLS{
 				SecretName: "challenge-certs",
 			},
@@ -742,7 +740,7 @@ func (r *InstanceReconciler) reconcileIngressRoute(ctx context.Context, instance
 		resolvedEndpoints = append(resolvedEndpoints, resEndpoint)
 		routes = []traefikv1alpha1.Route{
 			{
-				Kind:  "Rule",
+				Kind:  utils.RouteKindRule,
 				Match: fmt.Sprintf("Host(`%s`)", resEndpoint.Hostname),
 				Services: []traefikv1alpha1.Service{
 					{LoadBalancerSpec: traefikv1alpha1.LoadBalancerSpec{
@@ -762,7 +760,7 @@ func (r *InstanceReconciler) reconcileIngressRoute(ctx context.Context, instance
 			}
 			resolvedEndpoints = append(resolvedEndpoints, resEP)
 			route := traefikv1alpha1.Route{
-				Kind:  "Rule",
+				Kind:  utils.RouteKindRule,
 				Match: fmt.Sprintf("Host(`%s-%s.%s.%s`)", ep.Name, instance.Name, instance.Spec.Challenge.Slug, instance.Spec.Challenge.Domain),
 				Services: []traefikv1alpha1.Service{
 					{
@@ -824,8 +822,6 @@ func (r *InstanceReconciler) reconcileIngressRoute(ctx context.Context, instance
 
 			r.Recorder.Event(instance, corev1.EventTypeNormal, utils.EventReasonIngressUpdated,
 				fmt.Sprintf("Updated IngressRoute %s with %d route(s)", ingressRouteName, len(routes)))
-		} else {
-
 		}
 	}
 
@@ -908,7 +904,7 @@ func getTeamID(instance *challengesv1.Instance) string {
 	if instance.Spec.Team != nil {
 		return strconv.FormatInt(instance.Spec.Team.ID, 10)
 	}
-	return "dynamic"
+	return utils.TeamDynamic
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/tide/internal/controller/instance_controller_test.go
+++ b/tide/internal/controller/instance_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	challengesv1 "github.com/TheAlpha16/isolet/tide/api/v1"
+	"github.com/TheAlpha16/isolet/tide/utils"
 )
 
 var _ = Describe("Instance Controller", func() {
@@ -831,9 +832,9 @@ var _ = Describe("Instance Controller Unit Tests", func() {
 	Describe("equalIngressRouteSpec", func() {
 		It("should return true for equal specs", func() {
 			spec := &traefikv1alpha1.IngressRouteSpec{
-				EntryPoints: []string{"web", "websecure"},
+				EntryPoints: []string{utils.EntryPointWeb, utils.EntryPointWebsecure},
 				Routes: []traefikv1alpha1.Route{
-					{Kind: "Rule", Match: "Host(`example.com`)"},
+					{Kind: utils.RouteKindRule, Match: "Host(`example.com`)"},
 				},
 				TLS: &traefikv1alpha1.TLS{SecretName: "my-cert"},
 			}
@@ -842,20 +843,20 @@ var _ = Describe("Instance Controller Unit Tests", func() {
 
 		It("should return false for different entry points count", func() {
 			a := &traefikv1alpha1.IngressRouteSpec{
-				EntryPoints: []string{"web"},
+				EntryPoints: []string{utils.EntryPointWeb},
 			}
 			b := &traefikv1alpha1.IngressRouteSpec{
-				EntryPoints: []string{"web", "websecure"},
+				EntryPoints: []string{utils.EntryPointWeb, utils.EntryPointWebsecure},
 			}
 			Expect(equalIngressRouteSpec(a, b)).To(BeFalse())
 		})
 
 		It("should return false for different entry point values", func() {
 			a := &traefikv1alpha1.IngressRouteSpec{
-				EntryPoints: []string{"web"},
+				EntryPoints: []string{utils.EntryPointWeb},
 			}
 			b := &traefikv1alpha1.IngressRouteSpec{
-				EntryPoints: []string{"websecure"},
+				EntryPoints: []string{utils.EntryPointWebsecure},
 			}
 			Expect(equalIngressRouteSpec(a, b)).To(BeFalse())
 		})
@@ -863,13 +864,13 @@ var _ = Describe("Instance Controller Unit Tests", func() {
 		It("should return false for different route count", func() {
 			a := &traefikv1alpha1.IngressRouteSpec{
 				Routes: []traefikv1alpha1.Route{
-					{Kind: "Rule", Match: "Host(`a.com`)"},
+					{Kind: utils.RouteKindRule, Match: "Host(`a.com`)"},
 				},
 			}
 			b := &traefikv1alpha1.IngressRouteSpec{
 				Routes: []traefikv1alpha1.Route{
-					{Kind: "Rule", Match: "Host(`a.com`)"},
-					{Kind: "Rule", Match: "Host(`b.com`)"},
+					{Kind: utils.RouteKindRule, Match: "Host(`a.com`)"},
+					{Kind: utils.RouteKindRule, Match: "Host(`b.com`)"},
 				},
 			}
 			Expect(equalIngressRouteSpec(a, b)).To(BeFalse())

--- a/tide/internal/webhook/v1/instance_webhook.go
+++ b/tide/internal/webhook/v1/instance_webhook.go
@@ -136,7 +136,7 @@ func (v *InstanceCustomValidator) ValidateUpdate(_ context.Context, oldObj, newO
 	}
 
 	// allow changes in case of deletion
-	if !newInstance.ObjectMeta.DeletionTimestamp.IsZero() {
+	if !newInstance.DeletionTimestamp.IsZero() {
 		return nil, nil
 	}
 
@@ -230,7 +230,7 @@ func (v *InstanceCustomValidator) validateLifecycle(l *challengesv1.Lifecycle) e
 	}
 
 	// make sure availableAt is before expiresAt if both are set
-	if l.AvailableAt != nil && l.ExpiresAt != nil && l.AvailableAt.Time.After(l.ExpiresAt.Time) {
+	if l.AvailableAt != nil && l.ExpiresAt != nil && l.AvailableAt.After(l.ExpiresAt.Time) {
 		return fmt.Errorf("lifecycle.availableAt must be before lifecycle.expiresAt")
 	}
 

--- a/tide/utils/constants.go
+++ b/tide/utils/constants.go
@@ -1,6 +1,9 @@
 package utils
 
 const (
+	// Reconciliation Reasons
+	ReasonReconciliationFailed = "ReconciliationFailed"
+
 	// Event Reasons
 	EventReasonCreated                = "Created"
 	EventReasonStatusUpdateFailed     = "StatusUpdateFailed"
@@ -37,6 +40,17 @@ const (
 	LabelChallengeCID  = "challenges.isolet.dev/challenge-id"
 	LabelChallengeType = "challenges.isolet.dev/type"
 	LabelTeamID        = "challenges.isolet.dev/team"
+
+	// Label Values
+	LabelValInstance       = "instance"
+	LabelValTideController = "tide-controller"
+	LabelValDeployment     = "deployment"
+	TeamDynamic            = "dynamic"
+
+	// Traefik
+	EntryPointWeb       = "web"
+	EntryPointWebsecure = "websecure"
+	RouteKindRule       = "Rule"
 
 	// Condition Types
 	ConditionDeploymentReady = "DeploymentReady"


### PR DESCRIPTION
## Summary

- Extract Prometheus label names as package-level vars in `utils/tracer/metrics.go` for consistency across all metric definitions
- Add `ContextKeyChallengeID` constant to `utils/constants.go`; replace raw `"team_id"` and `"challenge_id"` string literals in repository files with shared constants (goconst)
- Extract token metadata key constants in auth usecase and smtp recipients key constant (goconst)
- Fix import-shadowing in usecase constructors: rename `cache` → `c`, `infra` → `svc`, `external` → `ext`; same for manifest and score usecases
- Wrap long function signatures and valkey builder chain calls to satisfy lll (120-char limit)

## Test plan

- [x] `golangci-lint run ./...` passes with 0 issues
- [x] `go build ./...` succeeds