### PR TITLE
ci: multi-arch Docker publish workflow + VERSION bump check

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,76 @@
+name: docker-publish
+
+on:
+  push:
+    branches: [develop]
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      services: ${{ steps.set-matrix.outputs.services }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            oracle:
+              - 'oracle/**'
+            tide:
+              - 'tide/**'
+            herald:
+              - 'herald/**'
+            proxy:
+              - 'proxy/**'
+            pulse:
+              - 'pulse/**'
+            ui:
+              - 'ui/**'
+
+      - name: Build service matrix
+        id: set-matrix
+        run: |
+          SERVICES=()
+          for svc in oracle tide herald proxy pulse ui; do
+            val=$(echo '${{ toJson(steps.filter.outputs) }}' | jq -r --arg s "$svc" '.[$s]')
+            if [ "$val" = "true" ]; then
+              SERVICES+=("$svc")
+            fi
+          done
+          echo "services=$(printf '%s\n' "${SERVICES[@]}" | jq -R . | jq -sc .)" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: changes
+    if: needs.changes.outputs.services != '[]' && needs.changes.outputs.services != ''
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJson(needs.changes.outputs.services) }}
+    name: Build & push ${{ matrix.service }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read VERSION
+        id: version
+        run: echo "tag=$(cat ${{ matrix.service }}/VERSION)" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./${{ matrix.service }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/isolet-${{ matrix.service }}:${{ steps.version.outputs.tag }}
+            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/isolet-${{ matrix.service }}:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,7 +39,11 @@ jobs:
               SERVICES+=("$svc")
             fi
           done
-          echo "services=$(printf '%s\n' "${SERVICES[@]}" | jq -R . | jq -sc .)" >> "$GITHUB_OUTPUT"
+          if [ ${#SERVICES[@]} -eq 0 ]; then
+            echo "services=[]" >> "$GITHUB_OUTPUT"
+          else
+            echo "services=$(printf '%s\n' "${SERVICES[@]}" | jq -R . | jq -sc .)" >> "$GITHUB_OUTPUT"
+          fi
 
   build:
     needs: changes

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,3 +69,29 @@ jobs:
       - run: mix compile --warnings-as-errors
         env:
           MIX_ENV: dev
+
+  version-check:
+    name: Version bump check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check VERSION bumped for changed services
+        run: |
+          BASE=${{ github.base_ref }}
+          git fetch origin "$BASE"
+          CHANGED_DIRS=$(git diff --name-only "origin/$BASE...HEAD" \
+            | grep -E '^(oracle|tide|herald|proxy|pulse|ui)/' \
+            | grep -v '/VERSION$' \
+            | cut -d/ -f1 | sort -u)
+
+          FAILED=false
+          for service in $CHANGED_DIRS; do
+            if ! git diff "origin/$BASE...HEAD" -- "$service/VERSION" | grep -qE '^\+[0-9]'; then
+              echo "::error file=$service/VERSION::$service has changes but VERSION was not bumped"
+              FAILED=true
+            fi
+          done
+          [ "$FAILED" = "true" ] && exit 1 || exit 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check VERSION bumped for changed services
+      - name: Check VERSION bumped and chart version in sync
         run: |
           BASE=${{ github.base_ref }}
           git fetch origin "$BASE"
@@ -92,6 +92,18 @@ jobs:
             if ! git diff "origin/$BASE...HEAD" -- "$service/VERSION" | grep -qE '^\+[0-9]'; then
               echo "::error file=$service/VERSION::$service has changes but VERSION was not bumped"
               FAILED=true
+              continue
+            fi
+
+            SERVICE_VERSION=$(cat "$service/VERSION")
+            CHART_VERSION=$(yq ".$service.version" charts/values.yaml)
+            if [ "$CHART_VERSION" != "null" ] && [ -n "$CHART_VERSION" ]; then
+              SV="${SERVICE_VERSION#v}"
+              CV="${CHART_VERSION#v}"
+              if [ "$SV" != "$CV" ]; then
+                echo "::error file=charts/values.yaml::$service VERSION ($SERVICE_VERSION) does not match charts/values.yaml .$service.version ($CHART_VERSION)"
+                FAILED=true
+              fi
             fi
           done
           [ "$FAILED" = "true" ] && exit 1 || exit 0

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -25,7 +25,7 @@ event:
 # Oracle — REST API + Kafka consumer (two deployments, same image)
 oracle:
   image: docker.io/thealpha16/isolet-oracle
-  version: "2.0.0"
+  version: "2.0.1"
   replicas: 2          # oracle-rest
   consumerReplicas: 1  # oracle-consumer
   token:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -53,7 +53,7 @@ oracle:
 # Pulse — Elixir/Phoenix WebSocket gateway
 pulse:
   image: docker.io/thealpha16/isolet-pulse
-  version: "1.2.0"
+  version: "0.2.0"
   replicas: 1
   kafka:
     brokers: "kafka-svc:9092"
@@ -64,7 +64,7 @@ pulse:
 # Herald — Go event emitter (k8s_source and postgres_source modes)
 herald:
   image: docker.io/thealpha16/isolet-herald
-  version: "1.0.0"
+  version: "0.1.0"
   k8sSource:
     enabled: true
     namespaces: "isolet,dynamic"
@@ -81,7 +81,7 @@ herald:
 # UI — Next.js frontend
 ui:
   image: docker.io/thealpha16/isolet-ui
-  version: "v2.0.5"
+  version: "2.0.0"
   replicas: 1
 
 # Proxy — Nginx reverse proxy

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -24,7 +24,7 @@ event:
 
 # Oracle — REST API + Kafka consumer (two deployments, same image)
 oracle:
-  image: docker.io/thealpha16/isolet-api
+  image: docker.io/thealpha16/isolet-oracle
   version: "2.0.0"
   replicas: 2          # oracle-rest
   consumerReplicas: 1  # oracle-consumer


### PR DESCRIPTION
## Summary

- Adds `docker-publish.yml` — triggers on merge to `develop`, detects which services changed, builds and pushes `linux/amd64` + `linux/arm64` images to Docker Hub tagged with the service's `VERSION` file and `:latest`
- Adds `version-check` job to `lint.yml` — fails PRs where a service has code changes but its `VERSION` file was not bumped

## Pre-requisites before merging

Add these two secrets to [repo settings](https://github.com/TheAlpha16/isolet/settings/secrets/actions):
- `DOCKERHUB_USERNAME` → `thealpha16`
- `DOCKERHUB_TOKEN` → Docker Hub access token with read/write/delete on repositories

## Test plan

- [ ] Open a PR that changes a file in `oracle/` without bumping `oracle/VERSION` → `version-check` should fail
- [ ] Bump `oracle/VERSION` → `version-check` passes
- [ ] Merge into `develop` → `docker-publish` triggers, only `oracle` build job runs, image pushed as `thealpha16/isolet-oracle:<version>` and `:latest`
- [ ] Merge a change touching only CI files → `docker-publish` triggers but `build` job is skipped (no changed services)